### PR TITLE
chore: update backup docs

### DIFF
--- a/docs/app-settings/backup.mdx
+++ b/docs/app-settings/backup.mdx
@@ -14,7 +14,7 @@ We plan to expand Polkadot Live's backup features in the near future to also sup
 
 :::
 
-This page will document application settings found under the `Backup` category in the settings window.
+This page documents application settings found under the `Backup` category in the settings window.
 
 <Img url="/img/app-settings/backup.png" />
 
@@ -23,12 +23,6 @@ This page will document application settings found under the `Backup` category i
 Clicking on the `Export` button will open a native OS dialog box, allowing you to save a file that stores your Polkadot Live account data in JSON format.
 
 Use the corresponding "Import" button in the settings window to select the exported data file and restore your accounts in Polkadot Live.
-
-:::note
-
-This feature currently supports **Vault** and **Read-Only** accounts.
-
-:::
 
 ## Import Accounts
 
@@ -39,11 +33,3 @@ After processing is complete, imported accounts will be available to manage in t
 :::info
 
 If the data file contains accounts that are already managed by Polkadot Live, those accounts will simply be ignored during the import process. Only accounts that Polkadot Live is not aware of will be imported.
-
-:::
-
-:::note
-
-This feature currently supports **Vault** and **Read-Only** accounts.
-
-:::


### PR DESCRIPTION
Polkadot Live now supports backing up accounts from all supported sources. This is now reflected in the docs.